### PR TITLE
Bumped gdx version number

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.daemon=false
 org.gradle.jvmargs=-Xms512M -Xmx4G -XX:MaxPermSize=1G -XX:MaxMetaspaceSize=1G
 org.gradle.configureondemand=false
 shapeDrawerVersion=2.3.0
-gdxVersion=1.9.11-SNAPSHOT
+gdxVersion=1.9.13


### PR DESCRIPTION
You used gdx version `11-snapshot` which doesn't build anymore. Therefore I updated it to the latest version.